### PR TITLE
Potential fix for code scanning alert no. 61: Multiplication result converted to larger type

### DIFF
--- a/src/arch/MovieTexture/MovieTexture_Null.cpp
+++ b/src/arch/MovieTexture/MovieTexture_Null.cpp
@@ -54,7 +54,7 @@ MovieTexture_Null::MovieTexture_Null(RageTextureID ID) : RageMovieTexture(ID)
 	const RageDisplay::RagePixelFormatDesc *pfd = DISPLAY->GetPixelFormatDesc( pixfmt );
 	RageSurface *img = CreateSurface( size, size, pfd->bpp,
 		pfd->masks[0], pfd->masks[1], pfd->masks[2], pfd->masks[3] );
-	memset( img->pixels, 0, img->pitch*img->h );
+	memset( img->pixels, 0, static_cast<size_t>(img->pitch) * img->h );
 
 	texHandle = DISPLAY->CreateTexture( pixfmt, img, false );
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/61](https://github.com/ScottBrenner/itgmania/security/code-scanning/61)

To fix the issue, we need to ensure that the multiplication is performed using a larger integer type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The fix involves modifying the `memset` call on line 57 to cast `img->pitch` or `img->h` to `size_t` before the multiplication. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
