### PR TITLE
Potential fix for code scanning alert no. 11: Mismatching new/free or malloc/delete

### DIFF
--- a/src/RageSurfaceUtils_Palettize.cpp
+++ b/src/RageSurfaceUtils_Palettize.cpp
@@ -305,7 +305,7 @@ void RageSurfaceUtils::Palettize( RageSurface *&pImg, int iColors, bool bDither 
 		}
 	}
 
-	delete acolormap;
+	free(acolormap);
 	delete [] thiserr;
 	delete [] nexterr;
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/11](https://github.com/ScottBrenner/itgmania/security/code-scanning/11)

To fix the issue, we need to ensure that the memory allocated with `malloc` is deallocated using `free` instead of `delete`. This change will align the memory allocation and deallocation methods, preventing undefined behavior. Specifically, we will replace the `delete acolormap` statement on line 308 with `free(acolormap)`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
