### PR TITLE
Potential fix for code scanning alert no. 479: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -500,7 +500,7 @@ static bool blit_same_type( const RageSurface *src_surf, const RageSurface *dst_
 	// The rows don't line up, so memcpy row by row.
 	while( height-- )
 	{
-		memcpy( dst, src, width*src_surf->format->BytesPerPixel );
+		memcpy( dst, src, (size_t)width * src_surf->format->BytesPerPixel );
 		src += src_surf->pitch;
 		dst += dst_surf->pitch;
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/479](https://github.com/ScottBrenner/itgmania/security/code-scanning/479)

To fix the issue, we need to ensure that the multiplication is performed in a type large enough to hold the result without overflow. Since the result is ultimately passed to `memcpy`, which expects a `size_t` argument, we can cast one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in `size_t`, avoiding overflow.

The specific change involves modifying the expression `width * src_surf->format->BytesPerPixel` on line 503 to `(size_t)width * src_surf->format->BytesPerPixel`. This change is localized and does not affect the rest of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
