### PR TITLE
Potential fix for code scanning alert no. 478: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -493,7 +493,7 @@ static bool blit_same_type( const RageSurface *src_surf, const RageSurface *dst_
 	// If possible, memcpy the whole thing.
 	if( src_surf->w == width && dst_surf->w == width && src_surf->pitch == dst_surf->pitch )
 	{
-		memcpy( dst, src, height*src_surf->pitch );
+		memcpy( dst, src, static_cast<size_t>(height) * src_surf->pitch );
 		return true;
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/478](https://github.com/ScottBrenner/itgmania/security/code-scanning/478)

To fix the issue, we need to ensure that the multiplication is performed in the larger type (`size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the `size_t` type, avoiding any risk of overflow in the intermediate result.

The specific change involves modifying the expression `height * src_surf->pitch` on line 496 to cast one of the operands (e.g., `height`) to `size_t`. This change is localized and does not affect the rest of the program's logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
