### PR TITLE
Potential fix for code scanning alert no. 475: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurfaceUtils.cpp
+++ b/src/RageSurfaceUtils.cpp
@@ -930,7 +930,7 @@ RageSurface *RageSurfaceUtils::MakeDummySurface( int height, int width )
 	RageSurfaceColor pink( 0xFF, 0x10, 0xFF, 0xFF );
 	ret_image->fmt.palette->colors[0] = pink;
 
-	memset( ret_image->pixels, 0, ret_image->h*ret_image->pitch );
+	memset( ret_image->pixels, 0, (size_t)ret_image->h * ret_image->pitch );
 
 	return ret_image;
 }


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/475](https://github.com/ScottBrenner/itgmania/security/code-scanning/475)

To fix the issue, we need to ensure that the multiplication is performed using a larger integer type (e.g., `size_t`) to prevent overflow. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This ensures that the multiplication is performed in the larger type, avoiding overflow.

The specific change involves modifying the expression `ret_image->h * ret_image->pitch` to `(size_t)ret_image->h * ret_image->pitch`. This change should be made on line 933 in the `memset` call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
