### PR TITLE
Potential fix for code scanning alert no. 474: Multiplication result converted to larger type

### DIFF
--- a/src/RageSurface.cpp
+++ b/src/RageSurface.cpp
@@ -137,8 +137,8 @@ RageSurface::RageSurface( const RageSurface &cpy )
 	pixels_owned = true;
 	if( cpy.pixels )
 	{
-		pixels = new uint8_t[ pitch*h ];
-		memcpy( pixels, cpy.pixels, pitch*h );
+		pixels = new uint8_t[ static_cast<size_t>(pitch) * h ];
+		memcpy( pixels, cpy.pixels, static_cast<size_t>(pitch) * h );
 	}
 	else
 		pixels = nullptr;


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/474](https://github.com/ScottBrenner/itgmania/security/code-scanning/474)

To fix the issue, we need to ensure that the multiplication `pitch * h` is performed using a larger type, such as `size_t`, before the result is used for memory allocation. This can be achieved by explicitly casting one of the operands to `size_t` before the multiplication. This approach ensures that the multiplication is performed in the larger type, preventing overflow.

The specific change involves modifying line 141 to cast `pitch` or `h` to `size_t` before the multiplication. No additional imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
