### PR TITLE
Potential fix for code scanning alert no. 473: Multiplication result converted to larger type

### DIFF
--- a/src/RageSoundReader_ChannelSplit.cpp
+++ b/src/RageSoundReader_ChannelSplit.cpp
@@ -196,7 +196,7 @@ int RageSoundSplitterImpl::ReadBuffer()
 	{
 		int iEraseFrames = iMinFrameRequested - m_iBufferPositionFrames;
 		iEraseFrames = std::min( iEraseFrames, (int) m_sBuffer.size() );
-		m_sBuffer.erase( m_sBuffer.begin(), m_sBuffer.begin() + iEraseFrames * m_pSource->GetNumChannels() );
+		m_sBuffer.erase( m_sBuffer.begin(), m_sBuffer.begin() + static_cast<std::size_t>(iEraseFrames) * m_pSource->GetNumChannels() );
 		m_iBufferPositionFrames += iEraseFrames;
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/473](https://github.com/ScottBrenner/itgmania/security/code-scanning/473)

To fix the issue, we need to ensure that the multiplication is performed in a larger integer type to prevent overflow. This can be achieved by explicitly casting one of the operands to a larger type (e.g., `long long` or `std::size_t`) before performing the multiplication. This ensures that the multiplication is carried out in the larger type, avoiding overflow.

The specific change involves casting `iEraseFrames` or `m_pSource->GetNumChannels()` to a larger type before the multiplication on line 199. This change does not alter the functionality but ensures that the calculation is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
