### PR TITLE
Potential fix for code scanning alert no. 483: Call to alloca in a loop

### DIFF
--- a/src/arch/Sound/ALSA9Helpers.cpp
+++ b/src/arch/Sound/ALSA9Helpers.cpp
@@ -167,15 +167,23 @@ void Alsa9Buf::GetSoundCardDebugInfo()
 			continue;
 		}
 
-		snd_ctl_card_info_t *info;
-		dsnd_ctl_card_info_alloca(&info);
-		err = dsnd_ctl_card_info( handle, info );
-		if ( err < 0 )
+		snd_ctl_card_info_t *info = (snd_ctl_card_info_t *)malloc(sizeof(snd_ctl_card_info_t));
+		if (!info)
 		{
-			LOG->Info( "Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err) );
-			dsnd_ctl_close( handle );
+			LOG->Warn("Memory allocation failed for snd_ctl_card_info_t");
+			dsnd_ctl_close(handle);
 			continue;
 		}
+		err = dsnd_ctl_card_info(handle, info);
+		if (err < 0)
+		{
+			LOG->Info("Couldn't get card info for card #%i (\"%s\"): %s", card, id.c_str(), dsnd_strerror(err));
+			free(info);
+			dsnd_ctl_close(handle);
+			continue;
+		}
+		// Use `info` as needed...
+		free(info);
 
 		int dev = -1;
 		while ( dsnd_ctl_pcm_next_device( handle, &dev ) >= 0 && dev >= 0 )


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgmania/security/code-scanning/483](https://github.com/ScottBrenner/itgmania/security/code-scanning/483)

To fix the issue, we will replace the use of `dsnd_ctl_card_info_alloca` with a heap allocation method, such as `malloc`, and ensure that the allocated memory is freed at the end of each loop iteration. This approach avoids the risk of stack overflow by allocating memory on the heap instead of the stack.

Steps to implement the fix:
1. Replace `dsnd_ctl_card_info_alloca(&info)` with a call to `malloc` to allocate memory for `info`.
2. Free the allocated memory using `free(info)` at the end of each loop iteration to prevent memory leaks.
3. Ensure that the replacement maintains the same functionality as the original code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
